### PR TITLE
chore: lock `govuk-frontend` to `4.5.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-promise": "^6.1.1",
-    "govuk-frontend": "^4.5.0",
+    "govuk-frontend": "4.5.0",
     "jest": "^29.4.3",
     "nunjucks": "^3.2.3",
     "ts-jest": "^29.0.5",


### PR DESCRIPTION
Locks the `govuk-frontend` package to the specific version.