### PR TITLE
fix: bump Nunjucks to v3.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4802,9 +4802,9 @@
       }
     },
     "node_modules/nunjucks": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
-      "integrity": "sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
+      "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
       "dev": true,
       "dependencies": {
         "a-sync-waterfall": "^1.0.0",

--- a/tests/component.test.ts
+++ b/tests/component.test.ts
@@ -20,8 +20,7 @@ const renderNunjucksComponent = (component: string, context: unknown) => {
     {},
   );
 
-  // In PHP: ' escapes to &#039.
-  // In Nunjucks: ' escapes to &#039.
+  // In Twig: ' escapes to &#039. In Nunjucks: ' escapes to &#039.
   return njk.replaceAll('&#39', '&#039');
 };
 
@@ -30,7 +29,8 @@ const renderTwigComponent = (component: string, context: unknown) => {
 
   const twig = twigBuffer.toString();
 
-  return twig;
+  // In Nunjucks: \ escapes to &#92. In Twig backslashes are not escaped.
+  return twig.replaceAll('\\', '&#92;');
 };
 
 describe.each(globalThis.components)('Nunjucks output HTML should match Twig output HTML', (componentFixture) => {


### PR DESCRIPTION
Bumps Nunjucks to `v3.2.4` to fix: https://github.com/advisories/GHSA-x77j-w7wf-fjmw