### PR TITLE
ci: tweak workflow naming

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: CD
 
 on:
   push:


### PR DESCRIPTION
**Description**:
Tweaks the workflow naming from `release` to `cd` to future-proof and allow for flexibility in the CD pipeline.